### PR TITLE
Update mentions of Develocity

### DIFF
--- a/docs/scan-tags.md
+++ b/docs/scan-tags.md
@@ -1,6 +1,6 @@
 # Build Scan Tags
 
-Gradle Doctor automatically [adds build scan tags](https://docs.gradle.com/enterprise/gradle-plugin/#extending_build_scans) to help categorize and filter builds when using [Gradle Enterprise](https://docs.gradle.com/enterprise/gradle-plugin/)
+Gradle Doctor automatically [adds build scan tags](https://docs.gradle.com/develocity/gradle-plugin/current/#extending_build_scans) to help categorize and filter builds when using [Develocity](https://gradle.com/develocity/).
 
 The `doctor` tag will be added to a build when a prescription is suggested by the Gradle Doctor.
 


### PR DESCRIPTION
Update remaining uses of "Gradle Enterprise" to Develocity. Link "Develocity" to the Develocity home page instead of the plugin manual.